### PR TITLE
fix: change lexer logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,10 +240,10 @@ fn hello() {
 > A blockquote with some content.
 "#;
         let html = parse_markdown(complex_markdown);
-        assert!(html.contains("MainTitle") || html.contains("Main Title"));
+        assert!(html.contains("Main Title"));
         assert!(html.contains("Subsection"));
-        assert!(html.contains("Firstitem") || html.contains("First item"));
-        assert!(html.contains("println!") || html.contains("Hello"));
+        assert!(html.contains("First item"));
+        assert!(html.contains("println!"));
         assert!(html.contains("blockquote"));
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1254,11 +1254,13 @@ impl<'input> Parser<'input> {
                 && colon_text.starts_with(':')
             {
                 self.advance()?; // consume ":"
+                self.skip_whitespace_text_tokens()?;
 
                 // Parse destination
                 if let Some(Token::Text(dest_text)) = &self.current_token {
                     let destination = dest_text.trim_matches(|c| c == '<' || c == '>').to_string();
                     self.advance()?; // consume destination
+                    self.skip_whitespace_text_tokens()?;
 
                     // Parse optional title
                     let mut title = None;
@@ -1284,7 +1286,7 @@ impl<'input> Parser<'input> {
                                 self.advance()?;
                             }
 
-                            let full_title = title_parts.join(" ");
+                            let full_title = title_parts.concat();
                             if full_title.starts_with('"') && full_title.ends_with('"') {
                                 title = Some(full_title[1..full_title.len() - 1].to_string());
                             }
@@ -1299,6 +1301,18 @@ impl<'input> Parser<'input> {
         }
 
         Ok(false)
+    }
+
+    /// Advances past any whitespace-only text tokens produced by the lexer.
+    fn skip_whitespace_text_tokens(&mut self) -> Result<()> {
+        while let Some(Token::Text(text)) = &self.current_token {
+            if text.chars().all(|c| c.is_whitespace()) {
+                self.advance()?;
+            } else {
+                break;
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
By modifying the Lexer logic, try to include spaces in the Text Token to solve the problem of missing spaces in the text content.